### PR TITLE
Use correct framework version in result file; restructure tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,8 @@ StyleCop.Cache
 local.settings.include
 InternalTrace.txt
 TestResult.xml
+NUnit3TestResult.xml
+NUnit2TestResult.xml
 testCaseCollection.xml
 deploy
 lib


### PR DESCRIPTION
Fixes #11 

Although the tests need work, I only did the minimum here in order to verify the fix...

* Dropped use of NUnit3 Cake Addin in favor of running console directly
* Saved result in both nunit3 and nunit2 formats to allow manual verification of the change

A full reworking of the tests is for a separate issue.
