### PR TITLE
Add tests to verify format of result file when there are multiple assemblies

### DIFF
--- a/NUnit2Results.xsd
+++ b/NUnit2Results.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:complexType name="failureType">
+		<xs:sequence>
+			<xs:element ref="message" />
+			<xs:element ref="stack-trace" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="reasonType">
+		<xs:sequence>
+			<xs:element ref="message" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="message" type="xs:string" />
+	<xs:complexType name="resultsType">
+		<xs:choice>
+			<xs:element name="test-suite" type="test-suiteType" maxOccurs="unbounded" />
+			<xs:element name="test-case" type="test-caseType" maxOccurs="unbounded" minOccurs="0" />
+		</xs:choice>
+	</xs:complexType>
+	<xs:element name="stack-trace" type="xs:string" />
+	<xs:element name="test-results" type="resultType" />
+	<xs:complexType name="categoriesType">
+		<xs:sequence>
+			<xs:element name="category" type="categoryType" maxOccurs="unbounded" minOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="categoryType">
+		<xs:attribute name="name" type="xs:string" use="required" />
+	</xs:complexType>
+	<xs:complexType name="propertiesType">
+		<xs:sequence>
+			<xs:element name="property" type="propertyType" maxOccurs="unbounded" minOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="propertyType">
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="value" type="xs:string" use="required" />
+	</xs:complexType>
+	<xs:complexType name="environmentType">
+		<xs:attribute name="nunit-version" type="xs:string" use="required" />
+		<xs:attribute name="clr-version" type="xs:string" use="required" />
+		<xs:attribute name="os-version" type="xs:string" use="required" />
+		<xs:attribute name="platform" type="xs:string" use="required" />
+		<xs:attribute name="cwd" type="xs:string" use="required" />
+		<xs:attribute name="machine-name" type="xs:string" use="required" />
+		<xs:attribute name="user" type="xs:string" use="required" />
+		<xs:attribute name="user-domain" type="xs:string" use="required" />
+	</xs:complexType>
+	<xs:complexType name="culture-infoType">
+		<xs:attribute name="current-culture" type="xs:string" use="required" />
+		<xs:attribute name="current-uiculture" type="xs:string" use="required" />
+	</xs:complexType>
+	<xs:complexType name="resultType">
+		<xs:sequence>
+			<xs:element name="environment" type="environmentType" />
+			<xs:element name="culture-info" type="culture-infoType" />
+			<xs:element name="test-suite" type="test-suiteType" />
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="total" type="xs:decimal" use="required" />
+    <xs:attribute name="errors" type="xs:decimal" use="required" />
+    <xs:attribute name="failures" type="xs:decimal" use="required" />
+    <xs:attribute name="inconclusive" type="xs:decimal" use="required" />
+    <xs:attribute name="not-run" type="xs:decimal" use="required" />
+    <xs:attribute name="ignored" type="xs:decimal" use="required" />
+    <xs:attribute name="skipped" type="xs:decimal" use="required" />
+    <xs:attribute name="invalid" type="xs:decimal" use="required" />
+    <xs:attribute name="date" type="xs:string" use="required" />
+		<xs:attribute name="time" type="xs:string" use="required" />
+	</xs:complexType>
+	<xs:complexType name="test-caseType">
+		<xs:sequence>
+			<xs:element name="categories" type="categoriesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1" />
+			<xs:choice>
+				<xs:element name="failure" type="failureType" minOccurs="0" />
+				<xs:element name="reason" type="reasonType" minOccurs="0" />
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="description" type="xs:string" use="optional" />
+		<xs:attribute name="success" type="xs:string" use="optional" />
+		<xs:attribute name="time" type="xs:string" use="optional" />
+		<xs:attribute name="executed" type="xs:string" use="required" />
+		<xs:attribute name="asserts" type="xs:string" use="optional" />
+    <xs:attribute name="result" type="xs:string" use="required" />
+  </xs:complexType>
+	<xs:complexType name="test-suiteType">
+		<xs:sequence>
+			<xs:element name="categories" type="categoriesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1" />
+			<xs:choice>
+				<xs:element name="failure" type="failureType" minOccurs="0" />
+				<xs:element name="reason" type="reasonType" minOccurs="0" />
+			</xs:choice>
+			<xs:element name="results" type="resultsType" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+    <xs:attribute name="type" type="xs:string" use="required" />
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="description" type="xs:string" use="optional" />
+		<xs:attribute name="success" type="xs:string" use="optional" />
+    <xs:attribute name="time" type="xs:string" use="optional" />
+		<xs:attribute name="executed" type="xs:string" use="required" />
+		<xs:attribute name="asserts" type="xs:string" use="optional" />
+    <xs:attribute name="result" type="xs:string" use="required" />
+  </xs:complexType>
+</xs:schema>

--- a/NUnit2Results.xsd
+++ b/NUnit2Results.xsd
@@ -55,7 +55,7 @@
 		<xs:sequence>
 			<xs:element name="environment" type="environmentType" />
 			<xs:element name="culture-info" type="culture-infoType" />
-			<xs:element name="test-suite" type="test-suiteType" />
+			<xs:element name="test-suite" type="test-suiteType" maxOccurs="unbounded" />
 		</xs:sequence>
 		<xs:attribute name="name" type="xs:string" use="required" />
 		<xs:attribute name="total" type="xs:decimal" use="required" />

--- a/TwoMockAssemblies.nunit
+++ b/TwoMockAssemblies.nunit
@@ -1,0 +1,7 @@
+<NUnitProject>
+  <Settings processModel="Default" domainUsage="Default" />
+  <Config name="Release" appbase="bin/Release">
+	  <assembly path="net20/mock-assembly.dll" />
+	  <assembly path="net20/mock-assembly.dll" />
+  </Config>
+</NUnitProject>

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.10.0
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.11.1
+#tool nuget:?package=NUnit.Extension.NUnitProjectLoader&version=3.6.0
 //#tool nuget:?package=NUnit.ConsoleRunner&version=3.12.0-beta1&prerelease
 
 ////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -113,7 +113,7 @@ Task("PackageNuGet")
 
 		tester.InstallPackage();
 		tester.VerifyPackage();
-		tester.TestPackage();
+		tester.RunPackageTests();
 
 		// In case of error, this will not be executed, leaving the directory available for examination
 		tester.UninstallPackage();
@@ -131,7 +131,7 @@ Task("PackageChocolatey")
 
 		tester.InstallPackage();
 		tester.VerifyPackage();
-		tester.TestPackage();
+		tester.RunPackageTests();
 
 		// In case of error, this will not be executed, leaving the directory available for examination
 		tester.UninstallPackage();

--- a/cake/packaging.cake
+++ b/cake/packaging.cake
@@ -27,11 +27,11 @@ static readonly Uri MAILING_LIST_URL = new Uri("https://groups.google.com/forum/
 // PACKAGE TESTER
 //////////////////////////////////////////////////////////////////////
 
+const string NUNIT3_RESULT_FILE = "NUnit3TestResult.xml";
+const string NUNIT2_RESULT_FILE = "NUnit2TestResult.xml";
+
 public abstract class PackageTester
 {
-	static readonly string NUNIT3_RESULT_FILE = "NUnit3TestResult.xml";
-	static readonly string NUNIT2_RESULT_FILE = "NUnit2TestResult.xml";
-
 	protected BuildParameters _parameters;
 	protected ICakeContext _context;
 
@@ -98,7 +98,7 @@ public abstract class PackageTester
 			RunConsoleTests(packageTest.ConsoleVersion, packageTest.Files);
 
 			Banner($"Verifying contents of {NUNIT2_RESULT_FILE}");
-			TestRunner.Run(typeof(ResultWriterTests));
+			TestRunner.Run(typeof(ResultWriterTests), typeof(SchemaValidationTests));
 		}
 	}
 

--- a/cake/packaging.cake
+++ b/cake/packaging.cake
@@ -46,28 +46,28 @@ public abstract class PackageTester
 	public abstract PackageCheck[] PackageChecks { get; }
 	public PackageTest[] PackageTests = new PackageTest[]
 	{
-		//new PackageTest()
-		//{
-		//	Description = "Run mock-assembly under 3.10.0 console",
-		//	Files = new [] {
-		//		$"bin/Release/net20/mock-assembly.dll" },
-		//	ConsoleVersion = "3.10.0"
-		//},
-		//new PackageTest()
-		//{
-		//	Description = "Run mock-assembly under 3.11.1 console",
-		//	Files = new [] {
-		//		$"bin/Release/net20/mock-assembly.dll" },
-		//	ConsoleVersion = "3.11.1"
-		//},
-		//new PackageTest()
-		//{
-		//	Description = "Run two copies of mock-assembly under 3.11.1 console",
-		//	Files = new [] {
-		//		$"bin/Release/net20/mock-assembly.dll",
-		//		$"bin/Release/net20/mock-assembly.dll" },
-		//	ConsoleVersion = "3.11.1"
-		//},
+		new PackageTest()
+		{
+			Description = "Run mock-assembly under 3.10.0 console",
+			Files = new [] {
+				$"bin/Release/net20/mock-assembly.dll" },
+			ConsoleVersion = "3.10.0"
+		},
+		new PackageTest()
+		{
+			Description = "Run mock-assembly under 3.11.1 console",
+			Files = new [] {
+				$"bin/Release/net20/mock-assembly.dll" },
+			ConsoleVersion = "3.11.1"
+		},
+		new PackageTest()
+		{
+			Description = "Run two copies of mock-assembly under 3.11.1 console",
+			Files = new [] {
+				$"bin/Release/net20/mock-assembly.dll",
+				$"bin/Release/net20/mock-assembly.dll" },
+			ConsoleVersion = "3.11.1"
+		},
 		new PackageTest()
 		{
 			Description = "Run NUnit project with files under 3.11.1 console",

--- a/cake/packaging.cake
+++ b/cake/packaging.cake
@@ -46,25 +46,35 @@ public abstract class PackageTester
 	public abstract PackageCheck[] PackageChecks { get; }
 	public PackageTest[] PackageTests = new PackageTest[]
 	{
+		//new PackageTest()
+		//{
+		//	Description = "Run mock-assembly under 3.10.0 console",
+		//	Files = new [] {
+		//		$"bin/Release/net20/mock-assembly.dll" },
+		//	ConsoleVersion = "3.10.0"
+		//},
+		//new PackageTest()
+		//{
+		//	Description = "Run mock-assembly under 3.11.1 console",
+		//	Files = new [] {
+		//		$"bin/Release/net20/mock-assembly.dll" },
+		//	ConsoleVersion = "3.11.1"
+		//},
+		//new PackageTest()
+		//{
+		//	Description = "Run two copies of mock-assembly under 3.11.1 console",
+		//	Files = new [] {
+		//		$"bin/Release/net20/mock-assembly.dll",
+		//		$"bin/Release/net20/mock-assembly.dll" },
+		//	ConsoleVersion = "3.11.1"
+		//},
 		new PackageTest()
 		{
-			ConsoleVersion = "3.10.0",
-			Assemblies = new [] {
-				$"bin/Release/net20/mock-assembly.dll" }
+			Description = "Run NUnit project with files under 3.11.1 console",
+			Files = new [] {
+				$"TwoMockAssemblies.nunit" },
+			ConsoleVersion = "3.11.1"
 		},
-		new PackageTest()
-		{
-			ConsoleVersion = "3.11.1",
-			Assemblies = new [] {
-				$"bin/Release/net20/mock-assembly.dll" }
-		},
-		new PackageTest()
-		{
-			ConsoleVersion = "3.11.1",
-			Assemblies = new [] {
-				$"bin/Release/net20/mock-assembly.dll",
-				$"bin/Release/net20/mock-assembly.dll" }
-		}
 	};
 
 	public void InstallPackage()
@@ -84,11 +94,10 @@ public abstract class PackageTester
     {
 		foreach (var packageTest in PackageTests)
 		{
-			var consoleVersion = packageTest.ConsoleVersion;
-			Banner($"Running test under NUnit3-Console {consoleVersion}");
-			RunConsoleTests(consoleVersion, packageTest.Assemblies);
+			Banner(packageTest.Description);
+			RunConsoleTests(packageTest.ConsoleVersion, packageTest.Files);
 
-			Banner($"Verifying {NUNIT2_RESULT_FILE}");
+			Banner($"Verifying contents of {NUNIT2_RESULT_FILE}");
 			TestRunner.Run(typeof(ResultWriterTests));
 		}
 	}
@@ -147,8 +156,9 @@ public abstract class PackageTester
 
 public class PackageTest
 {
+	public string Description { get; set; }
+	public string[] Files { get; set; }
 	public string ConsoleVersion { get; set; }
-	public string[] Assemblies { get; set; }
 }
 
 public class NuGetPackageTester : PackageTester

--- a/cake/parameters.cake
+++ b/cake/parameters.cake
@@ -82,14 +82,6 @@ public class BuildParameters
 	public string NuGetPackage => PackageDirectory + NUGET_ID + "." + PackageVersion + ".nupkg";
 	public string ChocolateyPackage => PackageDirectory + CHOCO_ID + "." + PackageVersion + ".nupkg";
 
-	// These are all used for the package tests. There must be
-	// a #tool directive for each one at the start of this file.
-	public string[] SupportedConsoleVersions => new string[] {
-		"3.10.0",
-		"3.11.1",
-		//"3.12.0-beta1"
-	};
-
 	public string GetPathToConsoleRunner(string version)
 	{
 		return ToolsDirectory + "NUnit.ConsoleRunner." + version + "/tools/nunit3-console.exe";

--- a/cake/test-runner.cake
+++ b/cake/test-runner.cake
@@ -5,6 +5,11 @@ using System.Reflection;
 
 //////////////////////////////////////////////////////////////////////
 // A tiny test framework for use in cake scripts.
+//
+// NOTE: This is an experiment, so it currently only handles a very
+// limited set of constraints and assertions needed by this project.
+// Eventiually, I'll combine various experiments in this and other
+// projects to a Cake version of TC-Lite.
 //////////////////////////////////////////////////////////////////////
 
 public static class TestRunner

--- a/cake/tests.cake
+++ b/cake/tests.cake
@@ -1,25 +1,39 @@
-public static class ResultWriterTests
+public class ResultWriterTests
 {
-    static XmlNode Fixture;
+    // NOTE: These test assume that we are only loading mock-assembly.dll in one
+    // or more copies. If other assemblies are to be used, then we will need to
+    // specify the expected results as part of package test.
+    const int TOTAL = 31;
+    const int ERRORS = 1;
+    const int FAILURES = 1;
+    const int NOTRUN = 10;
+    const int INCONCLUSIVE = 1;
+    const int IGNORED = 4;
+    const int SKIPPED = 3;
+    const int INVALID = 3;
 
-    static ResultWriterTests()
+    XmlNode Fixture;
+    XmlNodeList TopLevelSuites;
+
+    public ResultWriterTests()
     {
         var doc = new XmlDocument();
         doc.Load("NUnit2TestResult.xml");
         Fixture = doc.DocumentElement;
+        TopLevelSuites = Fixture.SelectNodes("test-suite");
     }
 
     [Test]
-    public static void TopLevelHierarchy()
+    public void TopLevelHierarchy()
     {
         Assert.That(Fixture.Name, Is.EqualTo("test-results"));
         Assert.That(Fixture, Has.One.Element("environment"));
         Assert.That(Fixture, Has.One.Element("culture-info"));
-        Assert.That(Fixture, Has.One.Element("test-suite"));
+        Assert.That(TopLevelSuites.Count, Is.GreaterThan(0));
     }
 
     [Test]
-    public static void TestSuitesHaveOneResultsElement()
+    public void TestSuitesHaveOneResultsElement()
     {
         var suites = Fixture.SelectNodes("//test-suite");
         Assert.That(suites.Count > 0, "No <test-suite> elements found in file");
@@ -33,7 +47,7 @@ public static class ResultWriterTests
     }
 
     [Test]
-    public static void TestCasesHaveResultsElementAsParent()
+    public void TestCasesHaveResultsElementAsParent()
     {
         var testCases = Fixture.SelectNodes("//test-case");
         foreach (XmlNode testCase in testCases)
@@ -41,36 +55,39 @@ public static class ResultWriterTests
     }
 
     [Test]
-    public static void TestResultsElement()
+    public void TestResultsElement()
     {
+        int n = TopLevelSuites.Count;
         Assert.That(Fixture, Has.Attribute("name").EqualTo("mock-assembly.dll"));
-        Assert.That(Fixture, Has.Attribute("total").EqualTo("31"));
-        Assert.That(Fixture, Has.Attribute("errors").EqualTo("1"));
-        Assert.That(Fixture, Has.Attribute("failures").EqualTo("1"));
-        Assert.That(Fixture, Has.Attribute("not-run").EqualTo("10"));
-        Assert.That(Fixture, Has.Attribute("inconclusive").EqualTo("1"));
-        Assert.That(Fixture, Has.Attribute("ignored").EqualTo("4"));
-        Assert.That(Fixture, Has.Attribute("skipped").EqualTo("3"));
-        Assert.That(Fixture, Has.Attribute("invalid").EqualTo("3"));
+        Assert.That(Fixture, Has.Attribute("total").EqualTo((TOTAL*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("errors").EqualTo((ERRORS*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("failures").EqualTo((FAILURES*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("not-run").EqualTo((NOTRUN*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("inconclusive").EqualTo((INCONCLUSIVE*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("ignored").EqualTo((IGNORED*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("skipped").EqualTo((SKIPPED*n).ToString()));
+        Assert.That(Fixture, Has.Attribute("invalid").EqualTo((INVALID*n).ToString()));
         Assert.That(Fixture, Has.Attribute("date"));
         Assert.That(Fixture, Has.Attribute("time"));
     }
 
     [Test]
-    public static void TopLevelTestSuite()
+    public void TopLevelTestSuites()
     {
-        XmlNode suite = Fixture.SelectSingleNode("test-suite");
-        Assert.That(suite, Has.Attribute("type").EqualTo("Assembly"));
-        Assert.That(suite, Has.Attribute("name").EqualTo("mock-assembly.dll"));
-        Assert.That(suite, Has.Attribute("executed").EqualTo("True"));
-        Assert.That(suite, Has.Attribute("result").EqualTo("Failure"));
-        Assert.That(suite, Has.Attribute("success").EqualTo("False"));
-        Assert.That(suite, Has.Attribute("time"));
-        Assert.That(suite, Has.Attribute("asserts").EqualTo("2"));
+        foreach (XmlNode suite in TopLevelSuites)
+        {
+            Assert.That(suite, Has.Attribute("type").EqualTo("Assembly"));
+            Assert.That(suite, Has.Attribute("name").EqualTo("mock-assembly.dll"));
+            Assert.That(suite, Has.Attribute("executed").EqualTo("True"));
+            Assert.That(suite, Has.Attribute("result").EqualTo("Failure"));
+            Assert.That(suite, Has.Attribute("success").EqualTo("False"));
+            Assert.That(suite, Has.Attribute("time"));
+            Assert.That(suite, Has.Attribute("asserts").EqualTo("2"));
+        }
     }
 
     [Test]
-    public static void EnvironmentElement()
+    public void EnvironmentElement()
     {
         XmlNode environment = Fixture.SelectSingleNode("environment");
         Assert.That(environment, Has.Attribute("nunit-version").EqualTo("3.11.0.0"));
@@ -84,7 +101,7 @@ public static class ResultWriterTests
     }
 
     [Test]
-    public static void CultureInfoElement()
+    public void CultureInfoElement()
     {
         XmlNode cultureInfo = Fixture.SelectSingleNode("culture-info");
         Assert.That(cultureInfo, Has.Attribute("current-culture"));

--- a/cake/tests.cake
+++ b/cake/tests.cake
@@ -13,14 +13,14 @@ public class ResultWriterTests
     const int INVALID = 3;
 
     XmlNode Fixture;
-    XmlNodeList TopLevelSuites;
+    XmlNodeList Assemblies;
 
     public ResultWriterTests()
     {
         var doc = new XmlDocument();
         doc.Load("NUnit2TestResult.xml");
         Fixture = doc.DocumentElement;
-        TopLevelSuites = Fixture.SelectNodes("test-suite");
+        Assemblies = Fixture.SelectNodes("//test-suite[@type='Assembly']");
     }
 
     [Test]
@@ -29,7 +29,7 @@ public class ResultWriterTests
         Assert.That(Fixture.Name, Is.EqualTo("test-results"));
         Assert.That(Fixture, Has.One.Element("environment"));
         Assert.That(Fixture, Has.One.Element("culture-info"));
-        Assert.That(TopLevelSuites.Count, Is.GreaterThan(0));
+        Assert.That(Assemblies.Count, Is.GreaterThan(0));
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class ResultWriterTests
     [Test]
     public void TestResultsElement()
     {
-        int n = TopLevelSuites.Count;
+        int n = Assemblies.Count;
         Assert.That(Fixture, Has.Attribute("name").EqualTo("mock-assembly.dll"));
         Assert.That(Fixture, Has.Attribute("total").EqualTo((TOTAL*n).ToString()));
         Assert.That(Fixture, Has.Attribute("errors").EqualTo((ERRORS*n).ToString()));
@@ -74,7 +74,7 @@ public class ResultWriterTests
     [Test]
     public void TopLevelTestSuites()
     {
-        foreach (XmlNode suite in TopLevelSuites)
+        foreach (XmlNode suite in Assemblies)
         {
             Assert.That(suite, Has.Attribute("type").EqualTo("Assembly"));
             Assert.That(suite, Has.Attribute("name").EqualTo("mock-assembly.dll"));

--- a/nunit-v2-result-writer.sln
+++ b/nunit-v2-result-writer.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.sh = build.sh
 		net20.engine.addins = net20.engine.addins
 		NuGet.config = NuGet.config
+		NUnit2Results.xsd = NUnit2Results.xsd
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mock-assembly", "src\mock-assembly\mock-assembly.csproj", "{6D160D73-AB70-47F3-9837-BB3A06125FFB}"

--- a/src/extension/NUnit2XmlResultWriter.cs
+++ b/src/extension/NUnit2XmlResultWriter.cs
@@ -69,11 +69,7 @@ namespace NUnit.Engine.Addins
             _xmlWriter = xmlWriter;
 
             InitializeXmlFile(result);
-
-            foreach (XmlNode child in result.ChildNodes)
-                if (child.Name.StartsWith("test-"))
-                    WriteResultElement(child);
-
+            WriteChildElements(result);
             TerminateXmlFile();
         }
 
@@ -306,13 +302,17 @@ namespace NUnit.Engine.Addins
         private void WriteChildResults(XmlNode result)
         {
             _xmlWriter.WriteStartElement("results");
+            WriteChildElements(result);
+            _xmlWriter.WriteEndElement();
+        }
 
+        private void WriteChildElements(XmlNode result)
+        {
             foreach (XmlNode childResult in result.ChildNodes)
                 if (childResult.Name.StartsWith("test-"))
                     WriteResultElement(childResult);
-
-            _xmlWriter.WriteEndElement();
         }
+
         #endregion
 
         #region Output Helpers

--- a/src/extension/NUnit2XmlResultWriter.cs
+++ b/src/extension/NUnit2XmlResultWriter.cs
@@ -77,8 +77,8 @@ namespace NUnit.Engine.Addins
         {
             NUnit2ResultSummary summary = new NUnit2ResultSummary(result);
 
-            XmlNode topLevelAssembly = result.SelectSingleNode("test-suite");
-            if (topLevelAssembly == null)
+            XmlNodeList assemblies = result.SelectNodes("//test-suite[@type='Assembly']");
+            if (assemblies.Count == 0)
                 throw new InvalidOperationException("Result contains no assemblies.");
 
             _xmlWriter.WriteStartDocument(false);
@@ -87,7 +87,7 @@ namespace NUnit.Engine.Addins
             _xmlWriter.WriteStartElement("test-results");
 
             // ERROR: Use attribute from ntop level child environment element here
-            _xmlWriter.WriteAttributeString("name", topLevelAssembly.GetAttribute("fullname") ?? "UNKNOWN");
+            _xmlWriter.WriteAttributeString("name", assemblies[0].GetAttribute("fullname") ?? "UNKNOWN");
             _xmlWriter.WriteAttributeString("total", summary.ResultCount.ToString());
             _xmlWriter.WriteAttributeString("errors", summary.Errors.ToString());
             _xmlWriter.WriteAttributeString("failures", summary.Failures.ToString());
@@ -100,7 +100,7 @@ namespace NUnit.Engine.Addins
             DateTime start = result.GetAttribute("start-time", DateTime.UtcNow);
             _xmlWriter.WriteAttributeString("date", start.ToString("yyyy-MM-dd"));
             _xmlWriter.WriteAttributeString("time", start.ToString("HH:mm:ss"));
-            WriteEnvironment(topLevelAssembly.SelectSingleNode("environment").GetAttribute("framework-version"));
+            WriteEnvironment(assemblies[0].SelectSingleNode("environment")?.GetAttribute("framework-version"));
             WriteCultureInfo();
         }
 

--- a/src/tests/nunit-v2-result-writer.tests.csproj
+++ b/src/tests/nunit-v2-result-writer.tests.csproj
@@ -12,6 +12,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Results.xsd" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="nunit.engine.api" Version="3.11.1" />
 
     <!-- This is the newest NUnit that support .NET Framework 2.0 -->


### PR DESCRIPTION
Closes #13

The actual request in #13 related to the XSD schema for the result file. However, the XSD is not in this project but in NUnit V2, where it will be modified. This PR merely adds additional package tests to verify the current behavior is correct.